### PR TITLE
Bugfix/connected field props duplicates

### DIFF
--- a/src/Fields/Field.jsx
+++ b/src/Fields/Field.jsx
@@ -69,13 +69,12 @@ export default class Field extends React.Component {
      * based on its value upon the composite mount. This causes issues of missing fields.
      */
     setTimeout(() => {
-      this.context.mapFieldToState({
-        fieldProps: {
-          ...this.props,
-          validated: false
-        },
-        fieldComponent: this
-      });
+      const fieldProps = {
+        ...this.props,
+        validated: false
+      };
+
+      this.context.mapFieldToState({ fieldProps });
     }, 0);
   }
 

--- a/src/Fields/Field.jsx
+++ b/src/Fields/Field.jsx
@@ -82,9 +82,6 @@ export default class Field extends React.Component {
     const { value: prevValue } = this.props;
     const { value: nextValue } = event.currentTarget;
 
-    // console.log(' ');
-    // console.log('| | Field @ handleChange', this.props.name, nextValue);
-
     /* Call parental change handler */
     this.context.handleFieldChange({
       event,
@@ -118,31 +115,27 @@ export default class Field extends React.Component {
 
   render() {
     /* Props passed to <Field /> on the client usage */
-    const { name, rule, asyncRule, valid, invalid, expected, validated, ...directProps } = this.props;
-
-    /**
-     * Input props.
-     * Props passed directly to the Field's element. Do not add
-     * properties which are not natively supported by that element.
-     */
-    const inputProps = {
-      value: this.getProp('value'),
-      required: this.getProp('required'),
-      disabled: this.getProp('disabled')
-    };
-
-    /**
-     * Event handlers assigned to the Field's element directly.
-     * Those handle changes which mutate the internal state/context.
-     */
-    const eventHandlers = {
-      onChange: this.handleChange,
-      onFocus: this.handleFocus,
-      onBlur: this.handleBlur
-    };
+    const {
+      name,
+      type,
+      id,
+      className,
+      style
+    } = this.props;
 
     return (
-      <input {...directProps} {...inputProps} {...eventHandlers} />
+      <input
+        name={ name }
+        type={ type }
+        id={ id }
+        className={ className }
+        style={ style }
+        value={ this.getProp('value') }
+        required={ this.getProp('required') }
+        disabled={ this.getProp('disabled') }
+        onChange={ this.handleChange }
+        onFocus={ this.handleFocus }
+        onBlur={ this.handleBlur } />
     );
   }
 }

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -105,9 +105,9 @@ export default class Form extends React.Component {
    * However, fields present in the composite components are still unkown to the Form. This method
    * is a handler for each unkown field registration attempt.
    * @param {object} fieldProps
-   * @param {ReactComponent} fieldComponent
+   * @param {ReactComponent} ref
    */
-  mapFieldToState = async ({ fieldProps, fieldComponent }) => {
+  mapFieldToState = async ({ fieldProps }) => {
     console.groupCollapsed(fieldProps.name, '@ mapFieldToState');
     console.log('fieldProps', fieldProps);
     console.groupEnd();
@@ -118,10 +118,7 @@ export default class Form extends React.Component {
     const shouldValidate = isset(fieldProps.value) && (fieldProps.value !== '');
     if (shouldValidate) this.validateField({ fieldProps });
 
-    const nextFields = fields.mergeIn([fieldProps.name], fromJS({
-      ...fieldProps,
-      fieldComponent
-    }));
+    const nextFields = fields.mergeIn([fieldProps.name], fromJS(fieldProps));
 
     this.setState({ fields: nextFields });
   }

--- a/src/connectField.jsx
+++ b/src/connectField.jsx
@@ -34,7 +34,11 @@ export default function connectField(WrappedComponent) {
 
       const props = {
         ...this.props,
-        fieldProps: { focused, disabled, expected, valid, invalid },
+        focused,
+        disabled,
+        expected,
+        valid,
+        invalid,
         value
       };
 

--- a/src/connectField.jsx
+++ b/src/connectField.jsx
@@ -27,7 +27,16 @@ export default function connectField(WrappedComponent) {
       const { name } = this.props;
 
       const fieldProps = fields.has(name) ? fields.get(name).toJS() : defaultProps;
-      const props = Object.assign({}, this.props, { fieldProps });
+      const { focused, disabled, expected, valid, invalid } = fieldProps;
+
+      /* Grab the value from context props when available, to present actual data in the components tree */
+      const value = fields.has(name) ? fields.getIn([name, 'value']) : this.props.value;
+
+      const props = {
+        ...this.props,
+        fieldProps: { focused, disabled, expected, valid, invalid },
+        value
+      };
 
       return React.createElement(WrappedComponent, props);
     }

--- a/stories/templates/MyInput.js
+++ b/stories/templates/MyInput.js
@@ -11,14 +11,14 @@ const inputStyles = {
 
 class MyCustomInput extends React.Component {
   render() {
-    const { name, valid, invalid, ...restProps } = this.props;
+    const { valid, invalid, ...restProps } = this.props;
 
     return (
       <div className="form-group" style={{ marginBottom: '1rem' }}>
         <div style={{ display: 'flex' }}>
-          <Field.Input name={ name } {...restProps} style={ inputStyles } />
+          <Field.Input {...this.props} style={ inputStyles } />
           { valid && (
-            <span style={{ color: 'green' }}>✓</span>
+            <span style={{ color: 'green', marginTop: '6px' }}>✓</span>
           ) }
         </div>
 

--- a/stories/templates/MyInput.js
+++ b/stories/templates/MyInput.js
@@ -11,8 +11,7 @@ const inputStyles = {
 
 class MyCustomInput extends React.Component {
   render() {
-    const { name, fieldProps, ...restProps } = this.props;
-    const { valid, invalid } = fieldProps;
+    const { name, valid, invalid, ...restProps } = this.props;
 
     return (
       <div className="form-group" style={{ marginBottom: '1rem' }}>


### PR DESCRIPTION
* Passes `fieldProps` as root-level props from `connectField`
* Grabs the `value` prop from the `context` when available, otherwise grab from `this.props.value` (for initial values propagation)
* Passes `this.props` entirely to `<Field.Input />` in custom styled field