### PR TITLE
Feature/validation messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-conform",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4906,6 +4906,15 @@
         "ua-parser-js": "0.7.17"
       }
     },
+    "feather-icons": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.0.1.tgz",
+      "integrity": "sha1-mPBgMsCNXQHUvX5hiMYFeBGPvX0=",
+      "dev": true,
+      "requires": {
+        "classnames": "2.2.5"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-conform",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React form.",
   "source": "src/index.js",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.4.0",
+    "feather-icons": "^4.0.1",
     "immutable": "^3.8.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.5.0",

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { fromJS, Map } from 'immutable';
 
 /* Internal modules */
-import { TValidationRules } from './FormProvider';
+import { TValidationRules, TValidationMessages } from './FormProvider';
 import { isset, fieldUtils } from './utils';
 
 export default class Form extends React.Component {
@@ -41,7 +41,8 @@ export default class Form extends React.Component {
    * Context which is accepted by Form.
    */
   static contextTypes = {
-    rules: TValidationRules
+    rules: TValidationRules,
+    messages: TValidationMessages
   }
 
   /**

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { fromJS, Map } from 'immutable';
 
 /* Internal modules */
-import { TValidationRules, TValidationMessages } from './FormProvider';
+import { TValidationRules } from './FormProvider';
 import { isset, fieldUtils } from './utils';
 
 export default class Form extends React.Component {

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -225,13 +225,13 @@ export default class Form extends React.Component {
     const { rules: customFormRules } = this.props;
     const { rules: contextFormRules } = this.context;
 
-    const expectedStatus = await fieldUtils.isExpected({
+    const validityStatus = await fieldUtils.isExpected({
       fieldProps,
       fields,
       formProps: this.props,
       formRules: customFormRules || contextFormRules || {}
     });
-    const { expected, reason } = expectedStatus;
+    const { expected } = validityStatus;
 
     /* Update the validity state of the field */
     const propsPatch = {
@@ -239,9 +239,15 @@ export default class Form extends React.Component {
       expected
     };
 
-    /* Get the validation message based on the reason */
+    /* Get the validation message based on the errorType */
     if (!expected) {
-      const errorMessage = fieldUtils.resolveErrorMessage(reason, this.context.messages, fieldProps);
+      const errorMessage = fieldUtils.getErrorMessage({
+        validityStatus,
+        messages: this.context.messages,
+        fieldProps,
+        formProps: this.props
+      });
+
       propsPatch.error = errorMessage;
     }
 

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -193,7 +193,10 @@ export default class Form extends React.Component {
       this.updateField({
         fieldPath,
         propsPatch: {
-          disabled: true
+          disabled: true,
+          valid: false,
+          invalid: false,
+          validating: true
         }
       });
 
@@ -206,7 +209,8 @@ export default class Form extends React.Component {
       fieldPath,
       propsPatch: {
         focused: false,
-        disabled: prevDisabled
+        disabled: prevDisabled,
+        validating: false
       }
     }).then(({ nextProps }) => {
       /* Invoke custom onBlur handler */

--- a/src/FormProvider.jsx
+++ b/src/FormProvider.jsx
@@ -11,18 +11,27 @@ export const TValidationRules = PropTypes.shape({
   name: PropTypes.object // name-specific field validation rules
 });
 
+export const TValidationMessages = PropTypes.shape({
+  general: PropTypes.object, // general validation messages
+  type: PropTypes.object, // type-specific validation messages
+  name: PropTypes.object // name-specific validation messages
+});
+
 export default class FormProvider extends React.Component {
   static propTypes = {
-    rules: TValidationRules
+    rules: TValidationRules,
+    messages: TValidationMessages
   }
 
   static childContextTypes = {
-    rules: TValidationRules
+    rules: TValidationRules,
+    messages: TValidationMessages
   }
 
   getChildContext() {
     return {
-      rules: this.props.rules
+      rules: this.props.rules,
+      messages: this.props.messages
     };
   }
 

--- a/src/FormProvider.jsx
+++ b/src/FormProvider.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { fromJS, Map } from 'immutable';
 
 export const TValidationRules = PropTypes.shape({
   type: PropTypes.object, // type-specific field validation rules
@@ -23,6 +24,10 @@ export default class FormProvider extends React.Component {
     messages: TValidationMessages
   }
 
+  static defaultProps = {
+    messages: Map()
+  }
+
   static childContextTypes = {
     rules: TValidationRules,
     messages: TValidationMessages
@@ -31,7 +36,7 @@ export default class FormProvider extends React.Component {
   getChildContext() {
     return {
       rules: this.props.rules,
-      messages: this.props.messages
+      messages: fromJS(this.props.messages)
     };
   }
 

--- a/src/connectField.jsx
+++ b/src/connectField.jsx
@@ -29,7 +29,7 @@ export default function connectField(WrappedComponent) {
 
       const fieldPath = fieldUtils.getFieldPath({ name, fieldGroup });
       const fieldProps = fields.hasIn([fieldPath]) ? fields.getIn([fieldPath]).toJS() : defaultProps;
-      const { focused, disabled, expected, valid, invalid, error } = fieldProps;
+      const { focused, disabled, validating, expected, valid, invalid, error } = fieldProps;
 
       /* Grab the value from context props when available, to present actual data in the components tree */
       const value = fields.hasIn([fieldPath]) ? fields.getIn([fieldPath, 'value']) : directProps.value;
@@ -39,6 +39,7 @@ export default function connectField(WrappedComponent) {
         ...directProps,
         focused,
         disabled,
+        validating,
         expected,
         valid,
         invalid,

--- a/src/connectField.jsx
+++ b/src/connectField.jsx
@@ -29,7 +29,7 @@ export default function connectField(WrappedComponent) {
 
       const fieldPath = fieldUtils.getFieldPath({ name, fieldGroup });
       const fieldProps = fields.hasIn([fieldPath]) ? fields.getIn([fieldPath]).toJS() : defaultProps;
-      const { focused, disabled, expected, valid, invalid } = fieldProps;
+      const { focused, disabled, expected, valid, invalid, error } = fieldProps;
 
       /* Grab the value from context props when available, to present actual data in the components tree */
       const value = fields.hasIn([fieldPath]) ? fields.getIn([fieldPath, 'value']) : directProps.value;
@@ -42,6 +42,7 @@ export default function connectField(WrappedComponent) {
         expected,
         valid,
         invalid,
+        error,
         value
       };
 

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -76,12 +76,8 @@ export async function isExpected({ fieldProps, fields, formProps, formRules = {}
   // console.log('value:', value);
 
   /* Allow non-required fields to be empty */
-  if (!value) {
-    // console.log('expected:', !required);
-    // console.groupEnd();
-
-    return !required;
-  }
+  if (!value && required) return { expected: false, reason: 'missing' };
+  if (!value && !required) return { expected: true };
 
   /* Assume Field doesn't have any specific validation attached */
   const formTypeRule = formRules.type && formRules.type[name];
@@ -91,7 +87,7 @@ export async function isExpected({ fieldProps, fields, formProps, formRules = {}
   if (!rule && !asyncRule && !hasFormRules) {
     // console.groupEnd();
 
-    return hasExpectedValue;
+    return { expected: true };
   }
 
   /* Format (sync) validation */
@@ -105,7 +101,7 @@ export async function isExpected({ fieldProps, fields, formProps, formRules = {}
     if (!hasExpectedValue) {
       // console.groupEnd();
 
-      return hasExpectedValue;
+      return { expected: false, reason: 'invalid' };
     }
   }
 
@@ -128,7 +124,7 @@ export async function isExpected({ fieldProps, fields, formProps, formRules = {}
     if (!hasExpectedValue) {
       // console.groupEnd();
 
-      return hasExpectedValue;
+      return { expected: false, reason: 'invalid' };
     }
   }
 
@@ -155,7 +151,17 @@ export async function isExpected({ fieldProps, fields, formProps, formRules = {}
   // console.log('hasExpectedValue:', hasExpectedValue);
   // console.groupEnd();
 
-  return hasExpectedValue;
+  return { expected: hasExpectedValue };
+}
+
+export function resolveErrorMessage(reason, messages, { name: fieldName }) {
+  const nameMessage = messages.getIn(['name', fieldName, reason]);
+  if (nameMessage) return nameMessage;
+
+  const typeMessage = messages.getIn(['type', fieldName, reason]);
+  if (typeMessage) return typeMessage;
+
+  return messages.getIn(['general', reason]);
 }
 
 /**

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -182,17 +182,23 @@ export function getErrorMessage({ validityStatus, messages, fieldProps, formProp
   const { errorType, asyncInfo } = validityStatus;
   const { name: fieldName } = fieldProps;
 
-  /* Name-specific messages has the highest priority */
-  const nameMessage = messages.getIn(['name', fieldName, errorType]);
-  if (nameMessage) return resolveAsyncMessage({ message: nameMessage, asyncInfo, errorType, fieldProps, formProps });
+  const messagePaths = [
+    /* Name-specific messages has the highest priority */
+    ['name', fieldName, errorType],
 
-  /* Type-specific messages has the middle priority */
-  const typeMessage = messages.getIn(['type', fieldName, errorType]);
-  if (typeMessage) return resolveAsyncMessage({ message: typeMessage, asyncInfo, errorType, fieldProps, formProps });
+    /* Type-specific messages has the middle priority */
+    ['type', fieldName, errorType],
 
-  /* General messages serve as the fallback ones */
-  const generalMessage = messages.getIn(['general', errorType]);
-  return resolveAsyncMessage({ message: generalMessage, asyncInfo, errorType, fieldProps, formProps });
+    /* General messages serve as the fallback ones */
+    ['general', errorType]
+  ];
+
+  /* Iterate through each message path and break as soon as the message is found */
+  for (let i = 0; i < messagePaths.length; i++) {
+    const messagePath = messagePaths[i];
+    const message = messages.getIn(messagePath);
+    if (message) return resolveAsyncMessage({ message, asyncInfo, errorType, fieldProps, formProps });
+  }
 }
 
 /**

--- a/stories/DefaultForm.js
+++ b/stories/DefaultForm.js
@@ -7,17 +7,38 @@ import MySelect from './templates/MySelect';
 const formRules = {
   name: {
     firstName: value => /^\w+$/.test(value),
-    username: value => (value === 'ab123')
+    // username: value => (value === 'ab123')
   }
 };
 
 const formMessages = {
+  general: {
+    missing: 'Please provide the required field',
+    invalid: 'Please provide a proper value',
+    async: {
+      defaultResolver: ({ payload }) => {
+        if (payload.statusCode === 'ERROR') return 'WS: The value is invalid';
+      }
+    }
+  },
   name: {
     numbersOnly: {
-      invalid: 'Only numbers are allowed!'
+      invalid: 'Only numbers are allowed!',
+      async: {
+        customResolver: ({ res }) => {
+          if (res.statusCode === 'FAILURE') return 'Validation failed';
+        }
+      }
     },
     firstName: {
       invalid: 'A name must contain letters.'
+    },
+    username: {
+      async: {
+        customResolver: ({ res, payload, fieldProps, formProps }) => {
+          return payload.statusCode;
+        }
+      }
     }
   }
 };
@@ -109,9 +130,7 @@ export default class DefaultForm extends Component {
               <MyInput
                 name="resolvableField"
                 value="Another value"
-                required={({ fields }) => {
-                  return fields.address && !!fields.address.value;
-                }} />
+                required={({ fields }) => fields.address && !!fields.address.value} />
             </label>
 
             <label>
@@ -135,6 +154,7 @@ export default class DefaultForm extends Component {
               </Field.Group>
             </label>
           </div>
+
           <button type="submit">Submit</button>
         </Form>
       </FormProvider>

--- a/stories/DefaultForm.js
+++ b/stories/DefaultForm.js
@@ -6,18 +6,18 @@ import MySelect from './templates/MySelect';
 /* Form validation rules */
 const formRules = {
   name: {
+    firstName: value => /^\w+$/.test(value),
     username: value => (value === 'ab123')
   }
 };
 
 const formMessages = {
-  general: {
-    missing: 'Please fill in the provided field.',
-    invalid: 'The value you provided is invalid.'
-  },
   name: {
+    numbersOnly: {
+      invalid: 'Only numbers are allowed!'
+    },
     firstName: {
-      numbersOnly: 'Only numbers are allowed!'
+      invalid: 'A name must contain letters.'
     }
   }
 };

--- a/stories/DefaultForm.js
+++ b/stories/DefaultForm.js
@@ -10,6 +10,18 @@ const formRules = {
   }
 };
 
+const formMessages = {
+  general: {
+    missing: 'Please fill in the provided field.',
+    invalid: 'The value you provided is invalid.'
+  },
+  name: {
+    firstName: {
+      numbersOnly: 'Only numbers are allowed!'
+    }
+  }
+};
+
 /* Composite field example */
 const FieldsComposition = () => (
   <div style={{ display: 'flex' }}>
@@ -41,7 +53,9 @@ export default class DefaultForm extends Component {
 
   render() {
     return (
-      <FormProvider rules={ formRules }>
+      <FormProvider
+        rules={ formRules }
+        messages={ formMessages }>
         <Form
           id="default-form-example"
           action={this.handleFormAction}

--- a/stories/templates/MyInput.js
+++ b/stories/templates/MyInput.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Field, connectField } from '../../src';
+import feather from 'feather-icons';
 
 const inputStyles = {
   border: '1px solid #ccc',
-  borderRadius: '3px',
+  borderRadius: 3,
   margin: 0,
   padding: '.45rem .65rem',
   fontSize: '14px'
@@ -11,19 +12,29 @@ const inputStyles = {
 
 class MyCustomInput extends React.Component {
   render() {
-    const { valid, invalid, ...restProps } = this.props;
+    const { valid, invalid, error, ...restProps } = this.props;
+
+    const iconOptions = { width: 16, height: 16 };
+
+    const borderColor = (valid && 'green') || (invalid && '#cc0000');
+    const iconColor = (valid && 'green') || (invalid && '#cc0000');
+    const icon = (valid && feather.icons.check.toSvg(iconOptions)) || (invalid && feather.icons['alert-circle'].toSvg(iconOptions));
 
     return (
       <div className="form-group" style={{ marginBottom: '1rem' }}>
-        <div style={{ display: 'flex' }}>
-          <Field.Input {...this.props} style={ inputStyles } />
-          { valid && (
-            <span style={{ color: 'green', marginTop: '6px' }}>✓</span>
+        <div style={{ display: 'inline-flex', position: 'relative' }}>
+          <Field.Input {...this.props} style={{ ...inputStyles, borderColor }} />
+          { (valid || invalid) && (
+            <span
+              style={{ position: 'absolute', height: 16, color: iconColor, top: 0, bottom: 0, margin: 'auto', right: 8 }}
+              dangerouslySetInnerHTML={{
+                __html: icon
+              }} />
           ) }
         </div>
 
         { invalid && (
-          <p style={{ color: 'red', marginTop: '4px' }}>Please provide a proper value.</p>
+          <p style={{ color: '#cc0000', marginTop: 4 }}>Error: { error }</p>
         ) }
       </div>
     );

--- a/stories/templates/MyInput.js
+++ b/stories/templates/MyInput.js
@@ -12,7 +12,7 @@ const inputStyles = {
 
 class MyCustomInput extends React.Component {
   render() {
-    const { valid, invalid, error, ...restProps } = this.props;
+    const { valid, invalid, error, validating, ...restProps } = this.props;
 
     const iconOptions = { width: 16, height: 16 };
 
@@ -32,6 +32,8 @@ class MyCustomInput extends React.Component {
               }} />
           ) }
         </div>
+
+        { validating && <p>Validating...</p> }
 
         { invalid && (
           <p style={{ color: '#cc0000', marginTop: 4 }}>Error: { error }</p>


### PR DESCRIPTION
## Changes
* Introduces `messages` prop to `FormProvider` responsible for providing validation messages to the Form
* Introduces basic resolving logic to grab the validation message from name-specific messages if present, then from type-specific and then from general, as a fallback
* Introduces a new `error` prop passed to `Field`, as well as to the custom connected fields via `connectField`
* Introduces async messages resolving logic. Each async message resolver is a function accepting a list of props and is expected to return a **string**. Async messages resolvers have the same priority logic as sync messages (name - type - general).
* Provided usage examples scenarios in the stories